### PR TITLE
mackerel-agent 導入方法を変更する

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,7 +3,7 @@ name: Ansible Lint
 on: [push]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ssh_args = -F ssh_config
 
 ## run ansible-playbook after set up private key
 
-```
+```console
 // dry-run
 $ ansible-playbook raspberrypi.yml -C
 

--- a/roles/co2sensor/tasks/main.yml
+++ b/roles/co2sensor/tasks/main.yml
@@ -5,6 +5,7 @@
     path: /boot/config.txt
     line: enable_uart=1
     create: yes
+    mode: 0644
 
 - name: pip install packages
   pip:
@@ -15,6 +16,7 @@
   file:
     path: /opt/co2sensor
     state: directory
+    mode: 0755
 
 - name: mackerel co2 plugin
   copy:

--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: mackerel-agent
     state: restarted
+    enabled: yes

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -7,57 +7,20 @@
     path: /usr/bin/mackerel-agent
   register: mackerel_agent
 
-- name: stat /usr/local/bin/mackerel-agent
-  stat:
-    path: /usr/local/bin/mackerel-agent
-  register: usr_local_bin_mackerel_agent
-
 - name: download mackerel-agent.deb
   get_url:
-    url: https://mackerel.io/file/agent/deb/mackerel-agent_latest.all.deb
+    url: https://github.com/mackerelio/mackerel-agent/releases/download/v0.72.1/mackerel-agent_0.72.1-1.systemd_armhf.deb
     dest: /tmp
   when:
     - not mackerel_agent.stat.exists
-    - not usr_local_bin_mackerel_agent.stat.exists
 
 - name: install mackerel-agent.deb
   apt:
-    deb: /tmp/mackerel-agent_latest.all.deb
-    update_cache: yes
-  when:
-    - not mackerel_agent.stat.exists
-    - not usr_local_bin_mackerel_agent.stat.exists
-
-- name: remove mackerel-agent via apt install .dev
-  file:
-    path: /usr/local/bin/mackerel-agent
-    state: absent
-  when:
-    - usr_local_bin_mackerel_agent.stat.exists
-
-- name: download mackerel-agent_linux_arm.tar.gz
-  get_url:
-    url: https://github.com/mackerelio/mackerel-agent/releases/download/v0.42.3/mackerel-agent_linux_arm.tar.gz
-    dest: /tmp
+    deb: /tmp/mackerel-agent_0.72.1-1.systemd_armhf.deb
   when:
     - not mackerel_agent.stat.exists
 
-- name: unarchive /tmp/mackerel-agent_linux_arm.tar.gz
-  unarchive:
-    remote_src: yes
-    src: /tmp/mackerel-agent_linux_arm.tar.gz
-    dest: /tmp
-  when: not mackerel_agent.stat.exists
-
-- name: mv /tmp/mackerel-agent_linux_arm/mackerel-agent /usr/bin
-  copy:
-    remote_src: True
-    src: /tmp/mackerel-agent_linux_arm/mackerel-agent
-    dest: /usr/bin
-    mode: '0644'
-  when: not mackerel_agent.stat.exists
-
-- name: setup mackerel-agent.conf
+- name: setup apikey to mackerel-agent.conf
   lineinfile: dest=/etc/mackerel-agent/mackerel-agent.conf
     line='{{ item.line }}'
     regexp='{{ item.regexp }}'


### PR DESCRIPTION
mackerel-agent の導入を変更し、よりシンプルでコード数を減らします。

## バージョンを 0.72.1 と固定にする理由

最新のバージョンを入れる様に latest で指定しようとも考えたが、
バージョンによる互換性の懸念がある為、 0.72.1 と固定値にします。

## mackerel-agent.conf の設定について

`mackerel-agent init --apikey=<api key>` で導入する様にします。
用意されているコマンドを利用することで、ステップ数を減らします。