### PR TITLE
CO2 濃度を LCD ディスプレイ表示する

### DIFF
--- a/raspberrypi.yml
+++ b/raspberrypi.yml
@@ -6,3 +6,5 @@
     - ssh
     - nodejs
     - monitoring
+    - co2sensor
+    - co2lcd

--- a/roles/co2lcd/files/show_co2_in_lcd.py
+++ b/roles/co2lcd/files/show_co2_in_lcd.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import board
+from PIL import Image, ImageDraw, ImageFont
+import adafruit_ssd1306
+import mh_z19
+import time
+
+font1 = ImageFont.truetype(
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 15)
+font2 = ImageFont.truetype(
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 10)
+font3 = ImageFont.truetype(
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 27)
+
+
+class CO2():
+    def __init__(self):
+        i2c = board.I2C()
+        self.display = adafruit_ssd1306.SSD1306_I2C(128, 32, i2c, addr=0x3c)
+
+    def initializeDisplay(self):
+        self.display.fill(0)
+        self.display.show()
+
+    def show(self):
+        latest_co2 = None
+        while True:
+            # get co2 concentration
+            co2 = self.co2Concentration()
+            if co2 != latest_co2:
+                latest_co2 = co2
+                # show co2 in lcd
+                self.showCO2InLCD(co2)
+            # sleep for 5 seconds each time
+            time.sleep(5)
+
+    def co2Concentration(self):
+        r = mh_z19.read()
+        if r is not None and 'co2' in r.keys():
+            return str(r['co2'])
+        return None
+
+    def showCO2InLCD(self, co2: str):
+        image = Image.new("1", (self.display.width, self.display.height))
+        self.draw = ImageDraw.Draw(image)
+
+        if co2 is None:
+            self.draw.text((0, 0), "ERROR", font=font1, fill=255)
+        else:
+            self.draw.text((0, 0), "CO2", font=font1, fill=255)
+            self.draw.text((10, 15), "ppm", font=font2, fill=255)
+            self.draw.text((40, 0), co2, font=font3, fill=255)
+
+        self.display.image(image)
+        self.display.show()
+
+
+if __name__ == '__main__':
+    co2 = CO2()
+    while True:
+        try:
+            co2.show()
+        except Exception:
+            pass
+        finally:
+            # initialize display when failed
+            co2.initializeDisplay()

--- a/roles/co2lcd/files/show_co2_in_lcd.service
+++ b/roles/co2lcd/files/show_co2_in_lcd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description = show co2 in lcd
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/home/pi/show_co2_in_lcd.py
+Restart=on-failure
+
+[Install]
+WantedBy = multi-user.target

--- a/roles/co2lcd/tasks/main.yml
+++ b/roles/co2lcd/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Install the apt packages for connecting to lcd
+  apt:
+    name:
+      - libopenjp2-7
+      - libtiff5
+      - fonts-noto-cjk
+
+- name: pip install packages
+  pip:
+    name:
+      - adafruit-blinka
+      - pillow
+      - adafruit-circuitpython-ssd1306
+
+- name: copy show_co2_in_lcd.py
+  copy:
+    src: show_co2_in_lcd.py
+    dest: show_co2_in_lcd.py
+    backup: no
+    mode: 0755
+
+- name: copy systemd file
+  copy:
+    src: show_co2_in_lcd.service
+    dest: /etc/systemd/system/show_co2_in_lcd.service
+    mode: 0644
+
+- name: enable show_co2_in_lcd.service
+  systemd:
+    name: show_co2_in_lcd
+    enabled: yes
+    state: started


### PR DESCRIPTION
CO2 濃度を mh_z19 モジュールで取得し adafruit_ssd1306 モジュールで LCD ディスプレイに表示する python スクリプトを用意し、
systemctl で daemon として実行します。

尚、 5秒おきに mh_z19 から CO2 濃度を取得し表示を変更します。